### PR TITLE
sort list of links in welcome compare page

### DIFF
--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -147,6 +147,11 @@ class DefaultController extends Controller
         ]);
     }
 
+    private static function compare(Versus $a, Versus $b) {
+        return strcmp($a->getSoftware1()->getName(), $b->getSoftware1()->getName());
+
+    }
+
     /**
      * @Route("comparatifs", name="listingVersus")
      */
@@ -157,6 +162,9 @@ class DefaultController extends Controller
         $em = $this->getDoctrine()->getManager();
 
         $listVersus = $em->getRepository(Versus::class)->findAll();
+
+
+        usort($listVersus, "self::compare");
 
         $defaultData = array(
             'message' => 'Choisissez 2 logiciels à comparer :',


### PR DESCRIPTION
Désolée, pas en anglais car trop dur à dire : 
pour la page d'accueil du comparatif, nous voulions une liste de liens vers les Versus existants, triés par ordre alphabétique. C'est fait, en prenant en compte le nom du premier software comparé. 