### PR TITLE
fix bug about import : bad use of method Next of spl file object

### DIFF
--- a/src/AppBundle/Service/ImportEntities.php
+++ b/src/AppBundle/Service/ImportEntities.php
@@ -224,7 +224,6 @@ class ImportEntities
 
                                 $column = 1;
                                 if (strtolower($row[0]) !== "ok") {
-                                    $splSoftFile->next();
                                 } else {
 
 
@@ -286,7 +285,6 @@ class ImportEntities
             foreach ($splSoftFile as $row) {
 
                 if (strtolower($row[0]) !== "ok") {
-                $splSoftFile->next();
                 } else {
 
                     array_shift($row);


### PR DESCRIPTION
En français : 
- le bug était le suivant : on hydratait qu'une ligne sur deux les lignes qu'on pouvait importer. 
- le problème venait de la méthode 'next" de l'object spl file object qu'on utilisait. En fait, on regardait si la ligne npouvait être importait, et si non, on utilisait la méthode next pour passer à la ligne suivante, mais en fait elle fait sauter 1 ligne en plus de la ligne courante, arg. 
- bug résolu, testé, en principe c'est ok