### PR TITLE
Fix auto wiring

### DIFF
--- a/app/Resources/datas/.~lock.import-tags.csv#
+++ b/app/Resources/datas/.~lock.import-tags.csv#
@@ -1,0 +1,1 @@
+,anne-laure,inspiron,25.01.2018 09:48,file:///home/anne-laure/.config/libreoffice/4;

--- a/src/AppBundle/Service/BoolsAsTags.php
+++ b/src/AppBundle/Service/BoolsAsTags.php
@@ -7,6 +7,7 @@ use AppBundle\Entity\SoftMain;
 use Doctrine\ORM\EntityManager;
 use Symfony\Component\Yaml\Yaml;
 use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Class BoolsAsTags :
@@ -26,10 +27,10 @@ class BoolsAsTags
 
     /**
      * BoolsAsTags constructor.
-     * @param EntityManager $em
+     * @param EntityManagerInterface $em
      * @param $rootDir
      */
-    public function __construct(EntityManager $em, $rootDir)
+    public function __construct(EntityManagerInterface $em, $rootDir)
     {
         $this->em = $em;
         $this->config = Yaml::parse(file_get_contents($rootDir . "/config/awesomeSearch.yml"));

--- a/src/AppBundle/Service/BoolsAsTags.php
+++ b/src/AppBundle/Service/BoolsAsTags.php
@@ -4,7 +4,6 @@ namespace AppBundle\Service;
 
 
 use AppBundle\Entity\SoftMain;
-use Doctrine\ORM\EntityManager;
 use Symfony\Component\Yaml\Yaml;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\ORM\EntityManagerInterface;

--- a/src/AppBundle/Service/ImportEntities.php
+++ b/src/AppBundle/Service/ImportEntities.php
@@ -5,12 +5,11 @@ namespace AppBundle\Service;
 use AppBundle\Entity\SoftMain;
 use AppBundle\Entity\SoftSeeAlso;
 use AppBundle\Entity\Tag;
-use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\DBAL\Connection;
-use Doctrine\ORM\EntityManager;
 use Symfony\Component\Yaml\Yaml;
 use SplFileObject;
-use AppBundle\Service\BoolsAsTags;
+use Doctrine\ORM\EntityManagerInterface;
+
 
 
 /**
@@ -34,7 +33,7 @@ class ImportEntities
 {
 
 
-    /** @var ObjectManager */
+    /** @var EntityManagerInterface */
     private $em;
     /**
      * @var Slugification
@@ -59,7 +58,7 @@ class ImportEntities
     private $boolsAsTags;
 
 
-    public function __construct(EntityManager $em, Slugification $slugificator, $rootDir, SeeAlso $serviceSeeAlso, BoolsAsTags $boolsAsTags)
+    public function __construct(EntityManagerInterface $em, Slugification $slugificator, $rootDir, SeeAlso $serviceSeeAlso, BoolsAsTags $boolsAsTags)
     {
         $this->slugificator = $slugificator;
         $this->em = $em;


### PR DESCRIPTION
in service Bools As Tags and service Import Entities : 
- fix implement Entity Manager Interface instead of Entity Manager

To test, just visit the entire website (especially page tags) and use moulinette. Look if there's no more warning in symfony barre. 